### PR TITLE
Add FastAPI backend with Docker support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3.8'
+
+services:
+  backend:
+    build:
+      context: .
+      dockerfile: src/backend/Dockerfile
+    ports:
+      - "8000:8000"
+    environment:
+      HOST: 0.0.0.0
+      PORT: 8000

--- a/src/backend/Dockerfile
+++ b/src/backend/Dockerfile
@@ -1,0 +1,23 @@
+FROM ubuntu:22.04
+
+# Install Python 3.9 and pip
+RUN apt-get update && \
+    apt-get install -y python3.9 python3-pip
+
+# Set the working directory
+WORKDIR /app
+
+# Copy the requirements file
+COPY requirements.txt .
+
+# Install the dependencies
+RUN pip install -r requirements.txt
+
+# Copy the contents of the current directory
+COPY . .
+
+# Expose the port
+EXPOSE 8000
+
+# Set the command to run the FastAPI app
+CMD ["python3", "./main.py"]

--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -1,0 +1,14 @@
+from fastapi import FastAPI
+import os
+
+app = FastAPI()
+
+@app.get("/")
+def read_root():
+    return {"message": "Hello, World!"}
+
+if __name__ == "__main__":
+    import uvicorn
+    host = os.getenv("HOST", "0.0.0.0")
+    port = int(os.getenv("PORT", 8000))
+    uvicorn.run(app, host=host, port=port)


### PR DESCRIPTION
Add a FastAPI GET example and Dockerize the backend.

* Add `src/backend/main.py` with a FastAPI application and a single GET endpoint returning "Hello, World!".
* Add `src/backend/Dockerfile` to package the backend in a Docker image using `ubuntu:22.04` as the base image.
* Add `docker-compose.yml` to manage Docker containers, setting `HOST` and `PORT` environment variables.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/hibana2077/AgentSmith/pull/1?shareId=ae9d920b-eacf-40ff-a2f7-bf4e3f8a21db).